### PR TITLE
Handle all unhandled promise rejections.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,11 @@ import { createHasuraMigration } from "./hasura";
 import { getMigrationFiles, getModifiedSqlFiles } from "./repo";
 import { watchPath } from "./watch";
 
+process.on('unhandledRejection', (error) => {
+  console.error(error);
+  process.exit(1);
+});
+
 const run = async () => {
   await yargs
     .usage("Usage: $0 <command> [options]")


### PR DESCRIPTION
This gives us a clearer error if something goes wrong when calling `hasura migrate`